### PR TITLE
chore: rename substrafoundation to substra

### DIFF
--- a/charts/hlf-k8s/CHANGELOG.md
+++ b/charts/hlf-k8s/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 10.2.1
+
+### Changed
+- Updated documentation
+
 ## 10.2.0
 
 ### Changed

--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: hlf-k8s
 description: Substra tools to configure the hyperledger fabric network
 type: application
-version: 10.2.0
+version: 10.2.1
 kubeVersion: ">= 1.19.0-0"
 home: https://github.com/Substra
 icon: https://avatars.githubusercontent.com/u/84009910?s=400

--- a/charts/hlf-k8s/UPGRADE.md
+++ b/charts/hlf-k8s/UPGRADE.md
@@ -22,7 +22,7 @@ chaincodes:
     port: 7052
     version: "1.0"
     image:
-      repository: substrafoundation/substra-chaincode
+      repository: substra/substra-chaincode
       tag: 0.1.1
       pullPolicy: IfNotPresent
 
@@ -49,7 +49,7 @@ chaincodes:
     port: 7052
     version: "1.0"
     image:
-      repository: substrafoundation/substra-chaincode
+      repository: substra/substra-chaincode
       tag: 0.1.1
       pullPolicy: IfNotPresent
 

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -49,13 +49,13 @@ chaincodes: []
 #   port: "7052"
 #   logLevel: INFO
 #   image:
-#     repository: substrafoundation/substra-chaincode
+#     repository: substra/substra-chaincode
 #     tag: 0.3.0
 #     pullPolicy: IfNotPresent
 #     pullImageSecret: docker-config
 #   init:
 #     image:
-#       repository: substrafoundation/substra-chaincode-init
+#       repository: substra/substra-chaincode-init
 #       tag: 0.3.0
 
 

--- a/examples/2-orgs-policy-any-no-ca-same-cc/skaffold.yaml
+++ b/examples/2-orgs-policy-any-no-ca-same-cc/skaffold.yaml
@@ -16,12 +16,12 @@ apiVersion: skaffold/v2beta12
 kind: Config
 build:
   artifacts:
-    - image: substrafoundation/fabric-tools
+    - image: substra/fabric-tools
       context: ../../
       docker:
         dockerfile: docker/fabric-tools/Dockerfile
 
-    - image: substrafoundation/fabric-peer
+    - image: substra/fabric-peer
       context: ../../
       docker:
         dockerfile: docker/fabric-peer/Dockerfile
@@ -38,7 +38,7 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
+          fabric-tools.image: substra/fabric-tools
 
       - name: network-org-1-peer-1
         chartPath: ../../charts/hlf-k8s
@@ -48,8 +48,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
       - name: network-org-2-peer-1
         chartPath: ../../charts/hlf-k8s
@@ -59,8 +59,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
   kubectl:
     manifests:

--- a/examples/2-orgs-policy-any-no-ca/skaffold.yaml
+++ b/examples/2-orgs-policy-any-no-ca/skaffold.yaml
@@ -16,12 +16,12 @@ apiVersion: skaffold/v2beta12
 kind: Config
 build:
   artifacts:
-    - image: substrafoundation/fabric-tools
+    - image: substra/fabric-tools
       context: ../../
       docker:
         dockerfile: docker/fabric-tools/Dockerfile
 
-    - image: substrafoundation/fabric-peer
+    - image: substra/fabric-peer
       context: ../../
       docker:
         dockerfile: docker/fabric-peer/Dockerfile
@@ -38,7 +38,7 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
+          fabric-tools.image: substra/fabric-tools
 
       - name: network-org-1-peer-1
         chartPath: ../../charts/hlf-k8s
@@ -48,8 +48,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
       - name: network-org-2-peer-1
         chartPath: ../../charts/hlf-k8s
@@ -59,8 +59,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
   kubectl:
     manifests:

--- a/examples/2-orgs-policy-any/skaffold.yaml
+++ b/examples/2-orgs-policy-any/skaffold.yaml
@@ -16,12 +16,12 @@ apiVersion: skaffold/v2beta12
 kind: Config
 build:
   artifacts:
-    - image: substrafoundation/fabric-tools
+    - image: substra/fabric-tools
       context: ../../
       docker:
         dockerfile: docker/fabric-tools/Dockerfile
 
-    - image: substrafoundation/fabric-peer
+    - image: substra/fabric-peer
       context: ../../
       docker:
         dockerfile: docker/fabric-peer/Dockerfile
@@ -38,7 +38,7 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
+          fabric-tools.image: substra/fabric-tools
 
       - name: network-org-1-peer-1
         chartPath: ../../charts/hlf-k8s
@@ -48,8 +48,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
 
       - name: network-org-2-peer-1
@@ -60,8 +60,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
   # We create the serviceAccounts with the kubectl deployer to ensure the serviceAccounts will stay present for the Helm deletion hooks
   # By design Skaffold create and delete ressources in a fixed order (Helm > kubectl > kustomize)

--- a/examples/3-orgs-policy-majority/skaffold.yaml
+++ b/examples/3-orgs-policy-majority/skaffold.yaml
@@ -22,12 +22,12 @@ apiVersion: skaffold/v2beta12
 kind: Config
 build:
   artifacts:
-    - image: substrafoundation/fabric-tools
+    - image: substra/fabric-tools
       context: ../../
       docker:
         dockerfile: docker/fabric-tools/Dockerfile
 
-    - image: substrafoundation/fabric-peer
+    - image: substra/fabric-peer
       context: ../../
       docker:
         dockerfile: docker/fabric-peer/Dockerfile
@@ -44,7 +44,7 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
+          fabric-tools.image: substra/fabric-tools
 
       - name: network-org-1-peer-1
         chartPath: ../../charts/hlf-k8s
@@ -54,8 +54,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
       - name: network-org-2-peer-1
         chartPath: ../../charts/hlf-k8s
@@ -65,8 +65,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
       - name: network-org-3-peer-1
         chartPath: ../../charts/hlf-k8s
@@ -76,8 +76,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
   kubectl:
     manifests:

--- a/examples/4-orgs-policy-any/skaffold.yaml
+++ b/examples/4-orgs-policy-any/skaffold.yaml
@@ -22,12 +22,12 @@ apiVersion: skaffold/v2beta12
 kind: Config
 build:
   artifacts:
-    - image: substrafoundation/fabric-tools
+    - image: substra/fabric-tools
       context: ../../
       docker:
         dockerfile: docker/fabric-tools/Dockerfile
 
-    - image: substrafoundation/fabric-peer
+    - image: substra/fabric-peer
       context: ../../
       docker:
         dockerfile: docker/fabric-peer/Dockerfile
@@ -44,7 +44,7 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
+          fabric-tools.image: substra/fabric-tools
 
       - name: network-org-1-peer-1
         chartPath: ../../charts/hlf-k8s
@@ -54,8 +54,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
       - name: network-org-2-peer-1
         chartPath: ../../charts/hlf-k8s
@@ -65,8 +65,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
       - name: network-org-3-peer-1
         chartPath: ../../charts/hlf-k8s
@@ -76,8 +76,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
       - name: network-org-4-peer-1
         chartPath: ../../charts/hlf-k8s
@@ -87,8 +87,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
   kubectl:
     manifests:

--- a/examples/4-orgs-policy-majority/skaffold.yaml
+++ b/examples/4-orgs-policy-majority/skaffold.yaml
@@ -22,12 +22,12 @@ apiVersion: skaffold/v2beta12
 kind: Config
 build:
   artifacts:
-    - image: substrafoundation/fabric-tools
+    - image: substra/fabric-tools
       context: ../../
       docker:
         dockerfile: docker/fabric-tools/Dockerfile
 
-    - image: substrafoundation/fabric-peer
+    - image: substra/fabric-peer
       context: ../../
       docker:
         dockerfile: docker/fabric-peer/Dockerfile
@@ -44,7 +44,7 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
+          fabric-tools.image: substra/fabric-tools
 
       - name: network-org-1-peer-1
         chartPath: ../../charts/hlf-k8s
@@ -54,8 +54,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
       - name: network-org-2-peer-1
         chartPath: ../../charts/hlf-k8s
@@ -65,8 +65,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
       - name: network-org-3-peer-1
         chartPath: ../../charts/hlf-k8s
@@ -76,8 +76,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
       - name: network-org-4-peer-1
         chartPath: ../../charts/hlf-k8s
@@ -87,8 +87,8 @@ deploy:
         imageStrategy:
           helm: {}
         artifactOverrides:
-          fabric-tools.image: substrafoundation/fabric-tools
-          hlf-peer.image: substrafoundation/fabric-peer
+          fabric-tools.image: substra/fabric-tools
+          hlf-peer.image: substra/fabric-peer
 
   kubectl:
     manifests:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Update all example skaffolds to use `substra` instead of `substrafoundation`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The image repository name was updated in the main skaffold but not in the examples.