### PR TITLE
chore(skaffold): update skaffold to 2.1.0

### DIFF
--- a/examples/2-orgs-policy-any-no-ca-same-cc/skaffold.yaml
+++ b/examples/2-orgs-policy-any-no-ca-same-cc/skaffold.yaml
@@ -12,63 +12,58 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v4beta2
 kind: Config
+requires:
+  - path: ../serviceAccounts/skaffold.yaml
+    configs:
+      # For chaincode secrets deletion
+      - org-1+2
+  - path: ../secrets/skaffold.yaml
 build:
   artifacts:
-    - image: substra/fabric-tools
-      context: ../../
-      docker:
-        dockerfile: docker/fabric-tools/Dockerfile
-
-    - image: substra/fabric-peer
-      context: ../../
-      docker:
-        dockerfile: docker/fabric-peer/Dockerfile
-
-deploy:
-  statusCheckDeadlineSeconds: 300
+  - image: substra/fabric-tools
+    context: ../../
+    docker:
+      dockerfile: docker/fabric-tools/Dockerfile
+  - image: substra/fabric-peer
+    context: ../../
+    docker:
+      dockerfile: docker/fabric-peer/Dockerfile
   helm:
     releases:
-      - name: network-orderer
-        chartPath: ../../charts/hlf-k8s
-        namespace: orderer
-        createNamespace: true
-        valuesFiles: [values/orderer.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-
-      - name: network-org-1-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-1
-        createNamespace: true
-        valuesFiles: [values/org-1-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-      - name: network-org-2-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-2
-        createNamespace: true
-        valuesFiles: [values/org-2-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-  kubectl:
-    manifests:
-      - ../secrets/secrets-orderer-genesis.yaml
-      - ../secrets/secrets-orderer.yaml
-      - ../secrets/secrets-org-1.yaml
-      - ../secrets/secrets-org-2.yaml
-      # For chaincode secrets deletion
-      - ../serviceAccounts/serviceAccount-org-1.yaml
-      - ../serviceAccounts/serviceAccount-org-2.yaml
-
+    - name: network-orderer
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/orderer.yaml
+      namespace: orderer
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+      createNamespace: true
+    - name: network-org-1-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-1-peer-1.yaml
+      namespace: org-1
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+    - name: network-org-2-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-2-peer-1.yaml
+      namespace: org-2
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+deploy:
+  helm: {}
+  kubectl: {}
+  statusCheckDeadlineSeconds: 300

--- a/examples/2-orgs-policy-any-no-ca-same-cc/values/orderer.yaml
+++ b/examples/2-orgs-policy-any-no-ca-same-cc/values/orderer.yaml
@@ -4,10 +4,6 @@ organization:
   id: MyOrdererMSP
   name: MyOrderer
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-peer:
   enabled: false
 

--- a/examples/2-orgs-policy-any-no-ca-same-cc/values/org-1-peer-1.yaml
+++ b/examples/2-orgs-policy-any-no-ca-same-cc/values/org-1-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg1MSP
   name: MyOrg1
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   enabled: false
   caName: rcaOrg1
@@ -19,7 +15,6 @@ hlf-ord:
 hlf-peer:
   host: network-org-1-peer-1-hlf-peer.org-1.svc.cluster.local
   image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-1-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-1-peer-1-svc-couchdb.org-1.svc.cluster.local
@@ -39,7 +34,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/2-orgs-policy-any-no-ca-same-cc/values/org-2-peer-1.yaml
+++ b/examples/2-orgs-policy-any-no-ca-same-cc/values/org-2-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg2MSP
   name: MyOrg2
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   enabled: false
   caName: rcaOrg2
@@ -18,8 +14,6 @@ hlf-ord:
 
 hlf-peer:
   host: network-org-2-peer-1-hlf-peer.org-2.svc.cluster.local
-  image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-2-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-2-peer-1-svc-couchdb.org-2.svc.cluster.local
@@ -39,7 +33,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/2-orgs-policy-any-no-ca/skaffold.yaml
+++ b/examples/2-orgs-policy-any-no-ca/skaffold.yaml
@@ -12,63 +12,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v4beta2
 kind: Config
+requires:
+  - path: ../serviceAccounts/skaffold.yaml
+    configs:
+      # For chaincode secrets deletion
+      - org-1+2
+  - path: ../secrets/skaffold.yaml
 build:
   artifacts:
-    - image: substra/fabric-tools
-      context: ../../
-      docker:
-        dockerfile: docker/fabric-tools/Dockerfile
-
-    - image: substra/fabric-peer
-      context: ../../
-      docker:
-        dockerfile: docker/fabric-peer/Dockerfile
-
-deploy:
-  statusCheckDeadlineSeconds: 300
+  - image: substra/fabric-tools
+    context: ../../
+    docker:
+      dockerfile: docker/fabric-tools/Dockerfile
+  - image: substra/fabric-peer
+    context: ../../
+    docker:
+      dockerfile: docker/fabric-peer/Dockerfile
+manifests:
   helm:
     releases:
-      - name: network-orderer
-        chartPath: ../../charts/hlf-k8s
-        namespace: orderer
-        createNamespace: true
-        valuesFiles: [values/orderer.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-
-      - name: network-org-1-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-1
-        createNamespace: true
-        valuesFiles: [values/org-1-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-      - name: network-org-2-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-2
-        createNamespace: true
-        valuesFiles: [values/org-2-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-  kubectl:
-    manifests:
-      - ../secrets/secrets-orderer-genesis.yaml
-      - ../secrets/secrets-orderer.yaml
-      - ../secrets/secrets-org-1.yaml
-      - ../secrets/secrets-org-2.yaml
-      # For chaincode secrets deletion
-      - ../serviceAccounts/serviceAccount-org-1.yaml
-      - ../serviceAccounts/serviceAccount-org-2.yaml
-
+    - name: network-orderer
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/orderer.yaml
+      namespace: orderer
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+      createNamespace: true
+    - name: network-org-1-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-1-peer-1.yaml
+      namespace: org-1
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+    - name: network-org-2-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-2-peer-1.yaml
+      namespace: org-2
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+deploy:
+  helm: {}
+  kubectl: {}
+  statusCheckDeadlineSeconds: 300

--- a/examples/2-orgs-policy-any-no-ca/values/orderer.yaml
+++ b/examples/2-orgs-policy-any-no-ca/values/orderer.yaml
@@ -4,10 +4,6 @@ organization:
   id: MyOrdererMSP
   name: MyOrderer
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-peer:
   enabled: false
 

--- a/examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml
+++ b/examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg1MSP
   name: MyOrg1
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   enabled: false
   caName: rcaOrg1
@@ -18,8 +14,6 @@ hlf-ord:
 
 hlf-peer:
   host: network-org-1-peer-1-hlf-peer.org-1.svc.cluster.local
-  image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-1-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-1-peer-1-svc-couchdb.org-1.svc.cluster.local
@@ -40,7 +34,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init
@@ -55,7 +48,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/2-orgs-policy-any-no-ca/values/org-2-peer-1.yaml
+++ b/examples/2-orgs-policy-any-no-ca/values/org-2-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg2MSP
   name: MyOrg2
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   enabled: false
   caName: rcaOrg2
@@ -18,8 +14,6 @@ hlf-ord:
 
 hlf-peer:
   host: network-org-2-peer-1-hlf-peer.org-2.svc.cluster.local
-  image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-2-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-2-peer-1-svc-couchdb.org-2.svc.cluster.local
@@ -39,7 +33,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init
@@ -52,7 +45,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/2-orgs-policy-any/skaffold.yaml
+++ b/examples/2-orgs-policy-any/skaffold.yaml
@@ -16,7 +16,7 @@ apiVersion: skaffold/v4beta2
 kind: Config
 requires:
   - path: ../serviceAccounts/skaffold.yaml
-    config:
+    configs:
       # For chaincode secrets deletion
       - org-1+2
       # We create the serviceAccounts with the kubectl deployer to ensure the serviceAccounts will stay present for the Helm deletion hooks

--- a/examples/2-orgs-policy-any/skaffold.yaml
+++ b/examples/2-orgs-policy-any/skaffold.yaml
@@ -12,62 +12,62 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v4beta2
 kind: Config
+requires:
+  - path: ../serviceAccounts/skaffold.yaml
+    config:
+      # For chaincode secrets deletion
+      - org-1+2
+      # We create the serviceAccounts with the kubectl deployer to ensure the serviceAccounts will stay present for the Helm deletion hooks
+      # By design Skaffold create and delete ressources in a fixed order (Helm > kubectl > kustomize)
+      # Ref: https://github.com/GoogleContainerTools/skaffold/blob/dedd545/pkg/skaffold/runner/new.go#L191-L214 (func getDeployer)
+      - orderer
 build:
   artifacts:
-    - image: substra/fabric-tools
-      context: ../../
-      docker:
-        dockerfile: docker/fabric-tools/Dockerfile
-
-    - image: substra/fabric-peer
-      context: ../../
-      docker:
-        dockerfile: docker/fabric-peer/Dockerfile
-
-deploy:
-  statusCheckDeadlineSeconds: 300
+  - image: substra/fabric-tools
+    context: ../../
+    docker:
+      dockerfile: docker/fabric-tools/Dockerfile
+  - image: substra/fabric-peer
+    context: ../../
+    docker:
+      dockerfile: docker/fabric-peer/Dockerfile
+manifests:
   helm:
     releases:
-      - name: network-orderer
-        chartPath: ../../charts/hlf-k8s
-        namespace: orderer
-        createNamespace: true
-        valuesFiles: [values/orderer.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-
-      - name: network-org-1-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-1
-        createNamespace: true
-        valuesFiles: [values/org-1-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-
-      - name: network-org-2-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-2
-        createNamespace: true
-        valuesFiles: [values/org-2-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-  # We create the serviceAccounts with the kubectl deployer to ensure the serviceAccounts will stay present for the Helm deletion hooks
-  # By design Skaffold create and delete ressources in a fixed order (Helm > kubectl > kustomize)
-  # Ref: https://github.com/GoogleContainerTools/skaffold/blob/dedd545/pkg/skaffold/runner/new.go#L191-L214 (func getDeployer)
-  kubectl:
-    manifests:
-      - ../serviceAccounts/serviceAccount-orderer.yaml
-      - ../serviceAccounts/serviceAccount-org-1.yaml
-      - ../serviceAccounts/serviceAccount-org-2.yaml
+    - name: network-orderer
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/orderer.yaml
+      namespace: orderer
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+      createNamespace: true
+    - name: network-org-1-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-1-peer-1.yaml
+      namespace: org-1
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+    - name: network-org-2-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-2-peer-1.yaml
+      namespace: org-2
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+deploy:
+  helm: {}
+  kubectl: {}
+  statusCheckDeadlineSeconds: 300

--- a/examples/2-orgs-policy-any/skaffold.yaml
+++ b/examples/2-orgs-policy-any/skaffold.yaml
@@ -33,7 +33,9 @@ build:
     context: ../../
     docker:
       dockerfile: docker/fabric-peer/Dockerfile
-manifests:
+
+# FIXME: Replace `deploy` by `manifests` when these functions are refactored https://github.com/owkin/substra-ci/blob/main/ci/deploy.py#L89 and https://github.com/owkin/substra-ci/blob/main/ci/deploy.py#L141
+deploy:
   helm:
     releases:
     - name: network-orderer
@@ -67,7 +69,4 @@ manifests:
         hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
         hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
       createNamespace: true
-deploy:
-  helm: {}
-  kubectl: {}
   statusCheckDeadlineSeconds: 300

--- a/examples/2-orgs-policy-any/values/orderer.yaml
+++ b/examples/2-orgs-policy-any/values/orderer.yaml
@@ -4,10 +4,6 @@ organization:
   id: MyOrdererMSP
   name: MyOrderer
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-peer:
   enabled: false
 

--- a/examples/2-orgs-policy-any/values/org-1-peer-1.yaml
+++ b/examples/2-orgs-policy-any/values/org-1-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg1MSP
   name: MyOrg1
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   caName: rcaOrg1
   host: network-org-1-peer-1-hlf-ca.org-1.svc.cluster.local
@@ -17,8 +13,6 @@ hlf-ord:
 
 hlf-peer:
   host: network-org-1-peer-1-hlf-peer.org-1.svc.cluster.local
-  image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-1-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-1-peer-1-svc-couchdb.org-1.svc.cluster.local
@@ -37,7 +31,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init
@@ -50,7 +43,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/2-orgs-policy-any/values/org-2-peer-1.yaml
+++ b/examples/2-orgs-policy-any/values/org-2-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg2MSP
   name: MyOrg2
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   caName: rcaOrg2
   host: network-org-2-peer-1-hlf-ca.org-2.svc.cluster.local
@@ -17,8 +13,6 @@ hlf-ord:
 
 hlf-peer:
   host: network-org-2-peer-1-hlf-peer.org-2.svc.cluster.local
-  image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-2-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-2-peer-1-svc-couchdb.org-2.svc.cluster.local
@@ -37,7 +31,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init
@@ -50,7 +43,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/3-orgs-policy-majority/skaffold.yaml
+++ b/examples/3-orgs-policy-majority/skaffold.yaml
@@ -18,70 +18,70 @@
 #   application channel policy ("MAJORITY")
 #
 ---
-apiVersion: skaffold/v2beta12
+requires:
+  - path: ../serviceAccounts/skaffold.yaml
+    configs:
+      - org-1+2
+      - org-3
+      - orderer
+apiVersion: skaffold/v4beta2
 kind: Config
 build:
   artifacts:
-    - image: substra/fabric-tools
-      context: ../../
-      docker:
-        dockerfile: docker/fabric-tools/Dockerfile
+  - image: substra/fabric-tools
+    context: ../../
+    docker:
+      dockerfile: docker/fabric-tools/Dockerfile
+  - image: substra/fabric-peer
+    context: ../../
+    docker:
+      dockerfile: docker/fabric-peer/Dockerfile
 
-    - image: substra/fabric-peer
-      context: ../../
-      docker:
-        dockerfile: docker/fabric-peer/Dockerfile
-
-deploy:
-  statusCheckDeadlineSeconds: 300
   helm:
     releases:
-      - name: network-orderer
-        chartPath: ../../charts/hlf-k8s
-        namespace: orderer
-        createNamespace: true
-        valuesFiles: [values/orderer.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-
-      - name: network-org-1-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-1
-        createNamespace: true
-        valuesFiles: [values/org-1-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-      - name: network-org-2-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-2
-        createNamespace: true
-        valuesFiles: [values/org-2-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-      - name: network-org-3-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-3
-        createNamespace: true
-        valuesFiles: [values/org-3-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-  kubectl:
-    manifests:
-      - ../serviceAccounts/serviceAccount-orderer.yaml
-      - ../serviceAccounts/serviceAccount-org-1.yaml
-      - ../serviceAccounts/serviceAccount-org-2.yaml
-      - ../serviceAccounts/serviceAccount-org-3.yaml
+    - name: network-orderer
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/orderer.yaml
+      namespace: orderer
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+      createNamespace: true
+    - name: network-org-1-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-1-peer-1.yaml
+      namespace: org-1
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+    - name: network-org-2-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-2-peer-1.yaml
+      namespace: org-2
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+    - name: network-org-3-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-3-peer-1.yaml
+      namespace: org-3
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+deploy:
+  helm: {}
+  kubectl: {}
+  statusCheckDeadlineSeconds: 300

--- a/examples/3-orgs-policy-majority/skaffold.yaml
+++ b/examples/3-orgs-policy-majority/skaffold.yaml
@@ -18,14 +18,14 @@
 #   application channel policy ("MAJORITY")
 #
 ---
+apiVersion: skaffold/v4beta2
+kind: Config
 requires:
   - path: ../serviceAccounts/skaffold.yaml
     configs:
       - org-1+2
       - org-3
       - orderer
-apiVersion: skaffold/v4beta2
-kind: Config
 build:
   artifacts:
   - image: substra/fabric-tools

--- a/examples/3-orgs-policy-majority/values/orderer.yaml
+++ b/examples/3-orgs-policy-majority/values/orderer.yaml
@@ -4,10 +4,6 @@ organization:
   id: MyOrdererMSP
   name: MyOrderer
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-peer:
   enabled: false
 

--- a/examples/3-orgs-policy-majority/values/org-1-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-1-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg1MSP
   name: MyOrg1
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   caName: rcaOrg1
   host: network-org-1-peer-1-hlf-ca.org-1.svc.cluster.local
@@ -17,8 +13,6 @@ hlf-ord:
 
 hlf-peer:
   host: network-org-1-peer-1-hlf-peer.org-1.svc.cluster.local
-  image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-1-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-1-peer-1-svc-couchdb.org-1.svc.cluster.local
@@ -37,7 +31,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/3-orgs-policy-majority/values/org-2-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-2-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg2MSP
   name: MyOrg2
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   caName: rcaOrg2
   host: network-org-2-peer-1-hlf-ca.org-2.svc.cluster.local
@@ -17,8 +13,6 @@ hlf-ord:
 
 hlf-peer:
   host: network-org-2-peer-1-hlf-peer.org-2.svc.cluster.local
-  image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-2-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-2-peer-1-svc-couchdb.org-2.svc.cluster.local
@@ -37,7 +31,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/3-orgs-policy-majority/values/org-3-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-3-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg3MSP
   name: MyOrg3
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   caName: rcaOrg3
   host: network-org-3-peer-1-hlf-ca.org-3.svc.cluster.local
@@ -17,8 +13,6 @@ hlf-ord:
 
 hlf-peer:
   host: network-org-3-peer-1-hlf-peer.org-3.svc.cluster.local
-  image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-3-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-3-peer-1-svc-couchdb.org-3.svc.cluster.local
@@ -37,7 +31,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/4-orgs-policy-any/skaffold.yaml
+++ b/examples/4-orgs-policy-any/skaffold.yaml
@@ -18,82 +18,81 @@
 #   application channel policy. A chosen node (here MyOrg1) is responsible
 #   for adding all the other nodes to the application channel.
 ---
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v4beta2
 kind: Config
+requires:
+- configs:
+  - org-1+2
+  - org-3
+  - org-4
+  - orderer
+  path: ../serviceAccounts/skaffold.yaml
 build:
   artifacts:
-    - image: substra/fabric-tools
-      context: ../../
-      docker:
-        dockerfile: docker/fabric-tools/Dockerfile
-
-    - image: substra/fabric-peer
-      context: ../../
-      docker:
-        dockerfile: docker/fabric-peer/Dockerfile
-
-deploy:
-  statusCheckDeadlineSeconds: 300
+  - image: substra/fabric-tools
+    context: ../../
+    docker:
+      dockerfile: docker/fabric-tools/Dockerfile
+  - image: substra/fabric-peer
+    context: ../../
+    docker:
+      dockerfile: docker/fabric-peer/Dockerfile
+manifests:
   helm:
     releases:
-      - name: network-orderer
-        chartPath: ../../charts/hlf-k8s
-        namespace: orderer
-        createNamespace: true
-        valuesFiles: [values/orderer.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-
-      - name: network-org-1-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-1
-        createNamespace: true
-        valuesFiles: [values/org-1-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-      - name: network-org-2-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-2
-        createNamespace: true
-        valuesFiles: [values/org-2-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-      - name: network-org-3-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-3
-        createNamespace: true
-        valuesFiles: [values/org-3-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-      - name: network-org-4-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-4
-        createNamespace: true
-        valuesFiles: [values/org-4-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-  kubectl:
-    manifests:
-      - ../serviceAccounts/serviceAccount-orderer.yaml
-      - ../serviceAccounts/serviceAccount-org-1.yaml
-      - ../serviceAccounts/serviceAccount-org-2.yaml
-      - ../serviceAccounts/serviceAccount-org-3.yaml
-      - ../serviceAccounts/serviceAccount-org-4.yaml
+    - name: network-orderer
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/orderer.yaml
+      namespace: orderer
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+      createNamespace: true
+    - name: network-org-1-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-1-peer-1.yaml
+      namespace: org-1
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+    - name: network-org-2-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-2-peer-1.yaml
+      namespace: org-2
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+    - name: network-org-3-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-3-peer-1.yaml
+      namespace: org-3
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+    - name: network-org-4-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-4-peer-1.yaml
+      namespace: org-4
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+deploy:
+  helm: {}
+  statusCheckDeadlineSeconds: 300

--- a/examples/4-orgs-policy-any/values/orderer.yaml
+++ b/examples/4-orgs-policy-any/values/orderer.yaml
@@ -4,10 +4,6 @@ organization:
   id: MyOrdererMSP
   name: MyOrderer
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-peer:
   enabled: false
 

--- a/examples/4-orgs-policy-any/values/org-1-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-1-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg1MSP
   name: MyOrg1
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   caName: rcaOrg1
   host: network-org-1-peer-1-hlf-ca.org-1.svc.cluster.local
@@ -17,8 +13,6 @@ hlf-ord:
 
 hlf-peer:
   host: network-org-1-peer-1-hlf-peer.org-1.svc.cluster.local
-  image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-1-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-1-peer-1-svc-couchdb.org-1.svc.cluster.local
@@ -37,7 +31,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/4-orgs-policy-any/values/org-2-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-2-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg2MSP
   name: MyOrg2
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   caName: rcaOrg2
   host: network-org-2-peer-1-hlf-ca.org-2.svc.cluster.local
@@ -17,8 +13,6 @@ hlf-ord:
 
 hlf-peer:
   host: network-org-2-peer-1-hlf-peer.org-2.svc.cluster.local
-  image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-2-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-2-peer-1-svc-couchdb.org-2.svc.cluster.local
@@ -37,7 +31,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/4-orgs-policy-any/values/org-3-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-3-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg3MSP
   name: MyOrg3
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   caName: rcaOrg3
   host: network-org-3-peer-1-hlf-ca.org-3.svc.cluster.local
@@ -17,8 +13,6 @@ hlf-ord:
 
 hlf-peer:
   host: network-org-3-peer-1-hlf-peer.org-3.svc.cluster.local
-  image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-3-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-3-peer-1-svc-couchdb.org-3.svc.cluster.local
@@ -37,7 +31,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/4-orgs-policy-any/values/org-4-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-4-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg4MSP
   name: MyOrg4
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   caName: rcaOrg4
   host: network-org-4-peer-1-hlf-ca.org-4.svc.cluster.local
@@ -17,8 +13,6 @@ hlf-ord:
 
 hlf-peer:
   host: network-org-4-peer-1-hlf-peer.org-4.svc.cluster.local
-  image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-4-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-4-peer-1-svc-couchdb.org-4.svc.cluster.local
@@ -37,7 +31,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/4-orgs-policy-majority/skaffold.yaml
+++ b/examples/4-orgs-policy-majority/skaffold.yaml
@@ -18,82 +18,82 @@
 #   application channel policy ("MAJORITY")
 #
 ---
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v4beta2
 kind: Config
+requires:
+  - path: ../serviceAccounts/skaffold.yaml
+    configs:
+      - org-1+2
+      - org-3
+      - org-4
+      - orderer
 build:
   artifacts:
-    - image: substra/fabric-tools
-      context: ../../
-      docker:
-        dockerfile: docker/fabric-tools/Dockerfile
-
-    - image: substra/fabric-peer
-      context: ../../
-      docker:
-        dockerfile: docker/fabric-peer/Dockerfile
-
-deploy:
-  statusCheckDeadlineSeconds: 300
+  - image: substra/fabric-tools
+    context: ../../
+    docker:
+      dockerfile: docker/fabric-tools/Dockerfile
+  - image: substra/fabric-peer
+    context: ../../
+    docker:
+      dockerfile: docker/fabric-peer/Dockerfile
+manifests:
   helm:
     releases:
-      - name: network-orderer
-        chartPath: ../../charts/hlf-k8s
-        namespace: orderer
-        createNamespace: true
-        valuesFiles: [values/orderer.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-
-      - name: network-org-1-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-1
-        createNamespace: true
-        valuesFiles: [values/org-1-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-      - name: network-org-2-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-2
-        createNamespace: true
-        valuesFiles: [values/org-2-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-      - name: network-org-3-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-3
-        createNamespace: true
-        valuesFiles: [values/org-3-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-      - name: network-org-4-peer-1
-        chartPath: ../../charts/hlf-k8s
-        namespace: org-4
-        createNamespace: true
-        valuesFiles: [values/org-4-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-  kubectl:
-    manifests:
-      - ../serviceAccounts/serviceAccount-orderer.yaml
-      - ../serviceAccounts/serviceAccount-org-1.yaml
-      - ../serviceAccounts/serviceAccount-org-2.yaml
-      - ../serviceAccounts/serviceAccount-org-3.yaml
-      - ../serviceAccounts/serviceAccount-org-4.yaml
+    - name: network-orderer
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/orderer.yaml
+      namespace: orderer
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+      createNamespace: true
+    - name: network-org-1-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-1-peer-1.yaml
+      namespace: org-1
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+    - name: network-org-2-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-2-peer-1.yaml
+      namespace: org-2
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+    - name: network-org-3-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-3-peer-1.yaml
+      namespace: org-3
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+    - name: network-org-4-peer-1
+      chartPath: ../../charts/hlf-k8s
+      valuesFiles:
+      - values/org-4-peer-1.yaml
+      namespace: org-4
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+deploy:
+  helm: {}
+  kubectl: {}
+  statusCheckDeadlineSeconds: 300

--- a/examples/4-orgs-policy-majority/values/orderer.yaml
+++ b/examples/4-orgs-policy-majority/values/orderer.yaml
@@ -4,10 +4,6 @@ organization:
   id: MyOrdererMSP
   name: MyOrderer
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-peer:
   enabled: false
 

--- a/examples/4-orgs-policy-majority/values/org-1-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-1-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg1MSP
   name: MyOrg1
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   caName: rcaOrg1
   host: network-org-1-peer-1-hlf-ca.org-1.svc.cluster.local
@@ -17,8 +13,6 @@ hlf-ord:
 
 hlf-peer:
   host: network-org-1-peer-1-hlf-peer.org-1.svc.cluster.local
-  image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-1-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-1-peer-1-svc-couchdb.org-1.svc.cluster.local
@@ -37,7 +31,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/4-orgs-policy-majority/values/org-2-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-2-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg2MSP
   name: MyOrg2
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   caName: rcaOrg2
   host: network-org-2-peer-1-hlf-ca.org-2.svc.cluster.local
@@ -17,8 +13,6 @@ hlf-ord:
 
 hlf-peer:
   host: network-org-2-peer-1-hlf-peer.org-2.svc.cluster.local
-  image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-2-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-2-peer-1-svc-couchdb.org-2.svc.cluster.local
@@ -37,7 +31,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/4-orgs-policy-majority/values/org-3-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-3-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg3MSP
   name: MyOrg3
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   caName: rcaOrg3
   host: network-org-3-peer-1-hlf-ca.org-3.svc.cluster.local
@@ -17,8 +13,6 @@ hlf-ord:
 
 hlf-peer:
   host: network-org-3-peer-1-hlf-peer.org-3.svc.cluster.local
-  image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-3-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-3-peer-1-svc-couchdb.org-3.svc.cluster.local
@@ -37,7 +31,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/4-orgs-policy-majority/values/org-4-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-4-peer-1.yaml
@@ -2,10 +2,6 @@ organization:
   id: MyOrg4MSP
   name: MyOrg4
 
-fabric-tools:
-  image:
-    pullImageSecret: docker-config
-
 hlf-ca:
   caName: rcaOrg4
   host: network-org-4-peer-1-hlf-ca.org-4.svc.cluster.local
@@ -17,8 +13,6 @@ hlf-ord:
 
 hlf-peer:
   host: network-org-4-peer-1-hlf-peer.org-4.svc.cluster.local
-  image:
-    pullImageSecret: docker-config
   peer:
     couchdbSecret: network-org-4-peer-1-hlf-k8s-couchdb-credentials
     couchdbService: network-org-4-peer-1-svc-couchdb.org-4.svc.cluster.local
@@ -37,7 +31,6 @@ chaincodes:
       repository: ghcr.io/substra/orchestrator-chaincode
       tag: latest
       pullPolicy: IfNotPresent
-      pullImageSecret: docker-config
     init:
       image:
         repository: ghcr.io/substra/orchestrator-chaincode-init

--- a/examples/secrets/skaffold.yaml
+++ b/examples/secrets/skaffold.yaml
@@ -1,7 +1,7 @@
 apiVersion: skaffold/v4beta2
 kind: Config
 metadata:
-  name: setup-secrets
+  name: common
 manifests:
   rawYaml:
   - ./secrets-orderer-genesis.yaml

--- a/examples/secrets/skaffold.yaml
+++ b/examples/secrets/skaffold.yaml
@@ -1,0 +1,10 @@
+apiVersion: skaffold/v4beta2
+kind: Config
+metadata:
+  name: setup-secrets
+manifests:
+  rawYaml:
+  - ./secrets-orderer-genesis.yaml
+  - ./secrets-orderer.yaml
+  - ./secrets-org-1.yaml
+  - ./secrets-org-2.yaml

--- a/examples/serviceAccounts/skaffold.yaml
+++ b/examples/serviceAccounts/skaffold.yaml
@@ -1,8 +1,32 @@
 apiVersion: skaffold/v4beta2
 kind: Config
 metadata:
-  name: setup-service-accounts
+  name: org-1+2
 manifests:
   rawYaml:
   - ./serviceAccount-org-1.yaml
   - ./serviceAccount-org-2.yaml
+---
+apiVersion: skaffold/v4beta2
+kind: Config
+metadata:
+  name: orderer
+manifests:
+  rawYaml:
+  - ./serviceAccount-orderer.yaml
+---
+apiVersion: skaffold/v4beta2
+kind: Config
+metadata:
+  name: org-3
+manifests:
+  rawYaml:
+  - ./serviceAccount-org-3.yaml
+---
+apiVersion: skaffold/v4beta2
+kind: Config
+metadata:
+  name: org-4
+manifests:
+  rawYaml:
+  - ./serviceAccount-org-4.yaml

--- a/examples/serviceAccounts/skaffold.yaml
+++ b/examples/serviceAccounts/skaffold.yaml
@@ -1,0 +1,8 @@
+apiVersion: skaffold/v4beta2
+kind: Config
+metadata:
+  name: setup-service-accounts
+manifests:
+  rawYaml:
+  - ./serviceAccount-org-1.yaml
+  - ./serviceAccount-org-2.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,95 +1,76 @@
-# Copyright 2018-2022 Owkin, inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
----
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v4beta2
 kind: Config
 build:
   artifacts:
-    - image: substra/fabric-tools
-      context: .
-      docker:
-        dockerfile: docker/fabric-tools/Dockerfile
-
-    - image: substra/fabric-peer
-      context: .
-      docker:
-        dockerfile: docker/fabric-peer/Dockerfile
-
-deploy:
-  statusCheckDeadlineSeconds: 300
+  - image: substra/fabric-tools
+    context: .
+    docker:
+      dockerfile: docker/fabric-tools/Dockerfile
+  - image: substra/fabric-peer
+    context: .
+    docker:
+      dockerfile: docker/fabric-peer/Dockerfile
+manifests:
+  rawYaml:
+  - examples/secrets/secrets-orderer-genesis.yaml
+  - examples/secrets/secrets-orderer.yaml
+  - examples/secrets/secrets-org-1.yaml
+  - examples/secrets/secrets-org-2.yaml
+  - examples/serviceAccounts/serviceAccount-org-1.yaml
+  - examples/serviceAccounts/serviceAccount-org-2.yaml
   helm:
     releases:
-      - name: network-orderer
-        chartPath: charts/hlf-k8s
-        namespace: orderer
-        createNamespace: true
-        valuesFiles: [examples/2-orgs-policy-any-no-ca/values/orderer.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-
-      - name: network-org-1-peer-1
-        skipBuildDependencies: true # deps already built by orderer release
-        chartPath: charts/hlf-k8s
-        namespace: org-1
-        createNamespace: true
-        valuesFiles: [examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-      - name: network-org-2-peer-1
-        skipBuildDependencies: true # deps already built by orderer release
-        chartPath: charts/hlf-k8s
-        namespace: org-2
-        createNamespace: true
-        valuesFiles: [examples/2-orgs-policy-any-no-ca/values/org-2-peer-1.yaml]
-        imageStrategy:
-          helm: {}
-        artifactOverrides:
-          fabric-tools.image: substra/fabric-tools
-          hlf-peer.image: substra/fabric-peer
-
-
-  kubectl:
-    manifests:
-      - examples/secrets/secrets-orderer-genesis.yaml
-      - examples/secrets/secrets-orderer.yaml
-      - examples/secrets/secrets-org-1.yaml
-      - examples/secrets/secrets-org-2.yaml
-      # For chaincode secrets deletion
-      - examples/serviceAccounts/serviceAccount-org-1.yaml
-      - examples/serviceAccounts/serviceAccount-org-2.yaml
-
+    - name: network-orderer
+      chartPath: charts/hlf-k8s
+      valuesFiles:
+      - examples/2-orgs-policy-any-no-ca/values/orderer.yaml
+      namespace: orderer
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+      createNamespace: true
+    - name: network-org-1-peer-1
+      chartPath: charts/hlf-k8s
+      valuesFiles:
+      - examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml
+      namespace: org-1
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+      skipBuildDependencies: true
+    - name: network-org-2-peer-1
+      chartPath: charts/hlf-k8s
+      valuesFiles:
+      - examples/2-orgs-policy-any-no-ca/values/org-2-peer-1.yaml
+      namespace: org-2
+      setValueTemplates:
+        fabric-tools.image.repository: '{{.IMAGE_REPO_substra_fabric_tools}}'
+        fabric-tools.image.tag: '{{.IMAGE_TAG_substra_fabric_tools}}@{{.IMAGE_DIGEST_substra_fabric_tools}}'
+        hlf-peer.image.repository: '{{.IMAGE_REPO_substra_fabric_peer}}'
+        hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
+      createNamespace: true
+      skipBuildDependencies: true
+deploy:
+  helm: {}
+  kubectl: {}
+  statusCheckDeadlineSeconds: 300
 profiles:
 - name: nodeps
   patches:
-    - op: add
-      path: /deploy/helm/releases/0/skipBuildDependencies
-      value: true
+  - op: add
+    path: /manifests/helm/releases/0/skipBuildDependencies
+    value: true
 - name: single-org
   patches:
-    - op: remove
-      path: /deploy/helm/releases/2
-
+  - op: remove
+    path: /manifests/helm/releases/2
     # Removes the org-2 manifests, at indexes 3 and 5.
     # we remove index 5 first because starting with index 3 turns index 5 into index 4 and that's
     # confusing.
-    - op: remove
-      path: /deploy/kubectl/manifests/5
-    - op: remove
-      path: /deploy/kubectl/manifests/3
+  - op: remove
+    path: /manifests/rawYaml/manifests/5
+  - op: remove
+    path: /manifests/rawYaml/manifests/3

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -14,6 +14,8 @@ build:
 requires:
   - path: examples/secrets/skaffold.yaml
   - path: examples/serviceAccounts/skaffold.yaml
+    configs: 
+      - org-1+2
 
 manifests:
   helm:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -17,7 +17,8 @@ requires:
     configs: 
       - org-1+2
 
-manifests:
+# FIXME: Replace `deploy` by `manifests` when these functions are refactored https://github.com/owkin/substra-ci/blob/main/ci/deploy.py#L89 and https://github.com/owkin/substra-ci/blob/main/ci/deploy.py#L141
+deploy:
   helm:
     releases:
     - name: network-orderer
@@ -53,20 +54,18 @@ manifests:
         hlf-peer.image.tag: '{{.IMAGE_TAG_substra_fabric_peer}}@{{.IMAGE_DIGEST_substra_fabric_peer}}'
       createNamespace: true
       skipBuildDependencies: true
-deploy:
-  helm: {}
   statusCheckDeadlineSeconds: 300
 
 profiles:
 - name: nodeps
   patches:
   - op: add
-    path: /manifests/helm/releases/0/skipBuildDependencies
+    path: /deploy/helm/releases/0/skipBuildDependencies
     value: true
 - name: single-org
   patches:
   - op: remove
-    path: /manifests/helm/releases/2
+    path: /deploy/helm/releases/2
     # Removes the org-2 manifests, at indexes 3 and 5.
     # we remove index 5 first because starting with index 3 turns index 5 into index 4 and that's
     # confusing.

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -10,14 +10,12 @@ build:
     context: .
     docker:
       dockerfile: docker/fabric-peer/Dockerfile
+  
+requires:
+  - path: examples/secrets/skaffold.yaml
+  - path: examples/serviceAccounts/skaffold.yaml
+
 manifests:
-  rawYaml:
-  - examples/secrets/secrets-orderer-genesis.yaml
-  - examples/secrets/secrets-orderer.yaml
-  - examples/secrets/secrets-org-1.yaml
-  - examples/secrets/secrets-org-2.yaml
-  - examples/serviceAccounts/serviceAccount-org-1.yaml
-  - examples/serviceAccounts/serviceAccount-org-2.yaml
   helm:
     releases:
     - name: network-orderer
@@ -55,8 +53,8 @@ manifests:
       skipBuildDependencies: true
 deploy:
   helm: {}
-  kubectl: {}
   statusCheckDeadlineSeconds: 300
+
 profiles:
 - name: nodeps
   patches:


### PR DESCRIPTION
## Companion PR

- https://github.com/Substra/orchestrator/pull/144
- https://github.com/Substra/substra-backend/pull/574

## Description

Update skaffold schema to `v4beta2` due to migration to Skaffold version `2.x.x` which was compatible with our schemas. It also removes a secret (`docker-config`) which was used in our closed-source era and creating error with the skaffold pipeline.