### PR TITLE
fix: upgrade fabric-tools libcurl

### DIFF
--- a/docker/fabric-tools/Dockerfile
+++ b/docker/fabric-tools/Dockerfile
@@ -1,8 +1,8 @@
-FROM hyperledger/fabric-tools:2.4
+FROM hyperledger/fabric-tools:2.5.0
 
 # Install curl and netcat
-RUN apk update && \
-  apk add curl netcat-openbsd vim libc6-compat
+RUN apt-get update && \
+  apt-get -y install curl netcat
 
 # Install fabric-ca-client
 RUN curl -SL https://github.com/hyperledger/fabric-ca/releases/download/v1.5.1/hyperledger-fabric-ca-linux-amd64-1.5.1.tar.gz | tar xz --strip-components=1 && \
@@ -14,6 +14,6 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.16.6/b
   mv ./kubectl /bin
 
 # Install grpcurl for convenience
-RUN wget https://github.com/fullstorydev/grpcurl/releases/download/v1.3.0/grpcurl_1.3.0_linux_x86_64.tar.gz && \
+RUN curl -LO https://github.com/fullstorydev/grpcurl/releases/download/v1.3.0/grpcurl_1.3.0_linux_x86_64.tar.gz && \
   tar xvzf grpcurl_1.3.0_linux_x86_64.tar.gz && \
   mv grpcurl /bin

--- a/docker/fabric-tools/Dockerfile
+++ b/docker/fabric-tools/Dockerfile
@@ -1,8 +1,9 @@
-FROM hyperledger/fabric-tools:2.5.0
+FROM hyperledger/fabric-tools:2.4
 
 # Install curl and netcat
-RUN apt-get update && \
-  apt-get -y install curl netcat
+RUN apk update && \
+  apk add curl netcat-openbsd vim libc6-compat && \
+  apk upgrade libcurl
 
 # Install fabric-ca-client
 RUN curl -SL https://github.com/hyperledger/fabric-ca/releases/download/v1.5.1/hyperledger-fabric-ca-linux-amd64-1.5.1.tar.gz | tar xz --strip-components=1 && \


### PR DESCRIPTION
Address this issue:

```shellsession
$ docker build . -f docker/fabric-tools/Dockerfile 
[...]
 => => extracting sha256:aa900656510dd0157ee615f22c06e1e698f033c0ada93f1b00  0.0s
 => [2/5] RUN apk update &&   apk add curl netcat-openbsd vim libc6-compat   4.2s
 => ERROR [3/5] RUN curl -SL https://github.com/hyperledger/fabric-ca/relea  0.3s
------                                                                            
 > [3/5] RUN curl -SL https://github.com/hyperledger/fabric-ca/releases/download/v1.5.1/hyperledger-fabric-ca-linux-amd64-1.5.1.tar.gz | tar xz --strip-components=1 &&   mv ./fabric-ca-client /bin:                                                 
#6 0.263 curl: (48) An unknown option was passed in to libcurl                    
#6 0.267 tar: invalid magic
#6 0.268 tar: short read
------
executor failed running [/bin/sh -c curl -SL https://github.com/hyperledger/fabric-ca/releases/download/v1.5.1/hyperledger-fabric-ca-linux-amd64-1.5.1.tar.gz | tar xz --strip-components=1 &&   mv ./fabric-ca-client /bin]: exit code: 1
```

The problem is that fabric-tools ditched Alpine for Ubuntu (in the 2.5 image), and so we're installing the newest version of curl onto an old Alpine release with mismatched libcurl.

We could update everything to 2.5 but that breaks the orderer and we don't want to spend time investigating. So instead this PR upgrades libcurl at the same time curl is installed.